### PR TITLE
Ljt 64 add postgre sql testcontainers support for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,11 @@ java {
 repositories {
 	mavenCentral()
 }
-
+configurations.configureEach {
+	resolutionStrategy {
+		force 'org.apache.commons:commons-compress:1.27.1'
+	}
+}
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'com.ryandens.javaagent-test' version '0.8.0'
 }
 
 group = 'com.coherentsolutions.pot'
@@ -30,6 +31,7 @@ dependencies {
 	testImplementation 'org.testcontainers:postgresql:1.21.3'
 	testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testJavaagent 'net.bytebuddy:byte-buddy-agent:1.15.11'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.testcontainers:postgresql:1.21.3'
+	testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,4 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,0 @@
-spring:
-  jpa:
-    hibernate:
-      ddl-auto: update

--- a/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
+++ b/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
@@ -1,10 +1,11 @@
 package com.coherentsolutions.pot.insurance_service;
 
+import com.coherentsolutions.pot.insurance_service.containers.PostgresTestContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class InsuranceServiceApplicationTests {
+class InsuranceServiceApplicationTests extends PostgresTestContainer {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
+++ b/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-
 class InsuranceServiceApplicationTests extends PostgresTestContainer {
 
 	@Test

--- a/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
+++ b/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
@@ -3,8 +3,10 @@ package com.coherentsolutions.pot.insurance_service;
 import com.coherentsolutions.pot.insurance_service.containers.PostgresTestContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class InsuranceServiceApplicationTests extends PostgresTestContainer {
 
 	@Test

--- a/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
+++ b/src/test/java/com/coherentsolutions/pot/insurance_service/InsuranceServiceApplicationTests.java
@@ -3,10 +3,9 @@ package com.coherentsolutions.pot.insurance_service;
 import com.coherentsolutions.pot.insurance_service.containers.PostgresTestContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
+
 class InsuranceServiceApplicationTests extends PostgresTestContainer {
 
 	@Test

--- a/src/test/java/com/coherentsolutions/pot/insurance_service/README.MD
+++ b/src/test/java/com/coherentsolutions/pot/insurance_service/README.MD
@@ -1,0 +1,25 @@
+## Integration Testing with Testcontainers
+
+This project uses [Testcontainers](https://www.testcontainers.org/) to spin up a real PostgreSQL instance during integration tests.
+
+### How it works
+
+- `PostgresTestContainer` (under `src/test/java/.../containers/`) sets up a fresh PostgreSQL container.
+- Tests that require the database should extend `PostgresTestContainer`.
+- The container is started automatically before the tests and stopped afterward.
+- This ensures all tests run in isolation against a clean PostgreSQL environment.
+
+### Example usage
+
+To run integration tests against a real PostgreSQL instance managed by Testcontainers, extend the
+shared `PostgresTestContainer` base class in your test:
+```java
+@SpringBootTest
+class YourTestClass extends PostgresTestContainer {
+    // Write your test methods here
+}
+```
+### Note:
+By extending PostgresTestContainer, your test class automatically starts a fresh
+PostgreSQL container and wires Spring Boot’s datasource properties to use it.
+

--- a/src/test/java/com/coherentsolutions/pot/insurance_service/containers/PostgresTestContainer.java
+++ b/src/test/java/com/coherentsolutions/pot/insurance_service/containers/PostgresTestContainer.java
@@ -11,10 +11,7 @@ public abstract class PostgresTestContainer {
 
     @Container
     public static final PostgreSQLContainer<?> POSTGRES =
-            new PostgreSQLContainer<>("postgres:16.9")
-                    .withDatabaseName("insurance_service")
-                    .withUsername("insurance_app")
-                    .withPassword("insurance_app_password");
+            new PostgreSQLContainer<>("postgres:16.9");
 
     @DynamicPropertySource
     static void overrideProps(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/coherentsolutions/pot/insurance_service/containers/PostgresTestContainer.java
+++ b/src/test/java/com/coherentsolutions/pot/insurance_service/containers/PostgresTestContainer.java
@@ -1,0 +1,25 @@
+package com.coherentsolutions.pot.insurance_service.containers;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class PostgresTestContainer {
+
+    @Container
+    public static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16.9")
+                    .withDatabaseName("insurance_service")
+                    .withUsername("insurance_app")
+                    .withPassword("insurance_app_password");
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+}


### PR DESCRIPTION
This PR introduces **TestContainers** integration using **PostgreSQL** for running **isolated** integration tests. 

- `PostgresTestContainer` base class to spin up a real PostgreSQL container using TestContainers. Container is spun up before tests start and spun down after the tests finish. 
- Added a `README.MD` under `src/test/java/...` to explain the usage.
- Added TestContainers dependencies and fixes for CVEs and minor errors. 

**Note**
Database schema management is handled by **LiquidBase**, instead of relying on Hibernate's `ddl-auto` to generate tables. 