### PR TITLE
Ljt 50 implement error handling

### DIFF
--- a/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -128,6 +129,27 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 servletRequest,
                 entry("value", ex.getValue()),
                 entry("requiredType", ex.getRequiredType().getSimpleName())
+        );
+        ErrorResponseDto error = new ErrorResponseDto(
+                ((HttpStatus) statusCode).name(),
+                summary,
+                details
+        );
+        return new ResponseEntity<>(error, headers, statusCode);
+    }
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(
+            HttpMediaTypeNotSupportedException ex,
+            @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode statusCode,
+            @NonNull WebRequest request) {
+        HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
+        String summary = "Unsupported media type '" + ex.getContentType() + "'";
+        assert ex.getContentType() != null;
+        Map<String, Object> details = buildDetails(
+                servletRequest,
+                entry("unsupported", ex.getContentType()),
+                entry("supported", ex.getSupportedMediaTypes())
         );
         ErrorResponseDto error = new ErrorResponseDto(
                 ((HttpStatus) statusCode).name(),

--- a/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
@@ -17,7 +17,6 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -150,6 +151,27 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 servletRequest,
                 entry("unsupported", ex.getContentType()),
                 entry("supported", ex.getSupportedMediaTypes())
+        );
+        ErrorResponseDto error = new ErrorResponseDto(
+                ((HttpStatus) statusCode).name(),
+                summary,
+                details
+        );
+        return new ResponseEntity<>(error, headers, statusCode);
+    }
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException ex,
+            @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode statusCode,
+            @NonNull WebRequest request) {
+        HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
+        String summary = "HTTP method '" + ex.getMethod() + "' is not supported for this endpoint";
+        assert ex.getSupportedMethods() != null;
+        Map<String, Object> details = buildDetails(
+                servletRequest,
+                entry("methodUsed", ex.getMethod()),
+                entry("supportedMethods", ex.getSupportedMethods())
         );
         ErrorResponseDto error = new ErrorResponseDto(
                 ((HttpStatus) statusCode).name(),

--- a/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.ServletWebRequest;
@@ -82,7 +83,29 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             @NonNull WebRequest request) {
         HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
         String summary = "Malformed JSON request";
-        Map<String, Object> details = buildDetails(servletRequest, entry("cause", ex.getMostSpecificCause().getMessage()));
+        Map<String, Object> details = buildDetails(
+                servletRequest,
+                entry("cause", ex.getMostSpecificCause().getMessage())
+        );
+        ErrorResponseDto error = new ErrorResponseDto(
+                ((HttpStatus) statusCode).name(),
+                summary,
+                details
+        );
+        return new ResponseEntity<>(error, headers, statusCode);
+    }
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex,
+            @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode statusCode,
+            @NonNull WebRequest request) {
+        HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
+        String summary = "Required request parameter '" + ex.getParameterName() + "' is missing";
+        Map<String, Object> details = buildDetails(
+                servletRequest,
+                entry("parameter", ex.getParameterName())
+        );
         ErrorResponseDto error = new ErrorResponseDto(
                 ((HttpStatus) statusCode).name(),
                 summary,

--- a/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import java.time.Instant;
 import java.util.HashMap;
@@ -173,6 +174,23 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 entry("methodUsed", ex.getMethod()),
                 entry("supportedMethods", ex.getSupportedMethods())
         );
+        ErrorResponseDto error = new ErrorResponseDto(
+                ((HttpStatus) statusCode).name(),
+                summary,
+                details
+        );
+        return new ResponseEntity<>(error, headers, statusCode);
+    }
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(
+            NoHandlerFoundException ex,
+            @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode statusCode,
+            @NonNull WebRequest request) {
+
+        HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
+        String summary = "No handler found for " + ex.getHttpMethod() + " " + ex.getRequestURL();
+        Map<String, Object> details = buildDetails(servletRequest);
         ErrorResponseDto error = new ErrorResponseDto(
                 ((HttpStatus) statusCode).name(),
                 summary,

--- a/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance_service/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.coherentsolutions.pot.insurance_service.exception;
 
 import com.coherentsolutions.pot.insurance_service.dto.error.ErrorResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -105,6 +106,28 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         Map<String, Object> details = buildDetails(
                 servletRequest,
                 entry("parameter", ex.getParameterName())
+        );
+        ErrorResponseDto error = new ErrorResponseDto(
+                ((HttpStatus) statusCode).name(),
+                summary,
+                details
+        );
+        return new ResponseEntity<>(error, headers, statusCode);
+    }
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(
+            TypeMismatchException ex,
+            @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode statusCode,
+            @NonNull WebRequest request) {
+        HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
+        String summary = "Type mismatch for parameter '" + ex.getPropertyName() + "'";
+        assert ex.getValue() != null;
+        assert ex.getRequiredType() != null;
+        Map<String, Object> details = buildDetails(
+                servletRequest,
+                entry("value", ex.getValue()),
+                entry("requiredType", ex.getRequiredType().getSimpleName())
         );
         ErrorResponseDto error = new ErrorResponseDto(
                 ((HttpStatus) statusCode).name(),


### PR DESCRIPTION
1. `buildDetails` **varargs** helper for construction of the `details` map (timestamp, endpoint, extra content on demand).
2. Overrides for some specific/common Spring exception handlers:

- `handleHttpMessageNotReadable` catches broken or no JSON, when one was expected. 
- `handleMissingServletRequestParameter` when a required HTTP header or query value is not given. 
- `handleTypeMismatch` when something of wrong type is sent.
- `handleHttpMediaTypeNotSupported` when wrong `Content-Type` is used. 
- `handleHttpRequestMethodNotSupported` when wrong HTTP method is used (GET instead of POST).
- `handleNoHandlerFoundException` if non-existent URL is used. 